### PR TITLE
fix: 일정 상태 변경 순서 검증 로직 수정 및 단건 조회 후 수정 오류 해결

### DIFF
--- a/src/main/java/com/taskflow/domain/task/controller/TaskController.java
+++ b/src/main/java/com/taskflow/domain/task/controller/TaskController.java
@@ -15,7 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * TaskController는 일정(Task) 관련 HTTP 요청을 처리합니다.
+ * TaskController는 일정(Task) 관련 HTTP 요청을 처리하는 컨트롤러
  */
 @RestController
 @RequiredArgsConstructor
@@ -25,11 +25,11 @@ public class TaskController {
     private final TaskService taskService;
 
     /**
-     * 새로운 일정을 생성합니다.
+     * 새로운 일정을 생성하는 API
      *
-     * @param request      일정 생성 요청 DTO
-     * @param userDetails  인증된 사용자 정보
-     * @return 생성된 일정 정보와 함께 API 응답 반환
+     * @param request     일정 생성 요청 DTO
+     * @param userDetails 인증된 사용자 정보
+     * @return 생성된 일정 상세 응답 DTO
      */
     @LogActivity(ActivityType.TASK_CREATED)
     @PostMapping
@@ -45,14 +45,15 @@ public class TaskController {
     }
 
     /**
-     * 일정 목록을 필터, 검색, 페이징 기준으로 조회합니다.
+     * 일정 목록을 조회하는 API
+     * 상태, 키워드, 담당자 ID 기준 필터링 및 페이징 지원
      *
-     * @param status      일정 상태 필터 (예: TODO, IN_PROGRESS)
-     * @param page        페이지 번호
-     * @param size        페이지 크기
-     * @param search      제목 또는 설명 키워드
-     * @param assigneeId  담당자 ID로 필터링
-     * @return 조건에 맞는 일정 목록과 페이징 정보 포함 API 응답
+     * @param status     일정 상태 필터 (예: TODO, IN_PROGRESS)
+     * @param page       페이지 번호
+     * @param size       페이지 크기
+     * @param search     제목 또는 설명 키워드
+     * @param assigneeId 담당자 ID
+     * @return 일정 목록 및 페이징 응답 DTO
      */
     @GetMapping
     public ResponseEntity<ApiResponse<TaskPageResponse>> getTasks(
@@ -69,10 +70,10 @@ public class TaskController {
     }
 
     /**
-     * 일정 ID를 기반으로 단건 일정을 조회합니다.
+     * 일정 단건을 조회하는 API
      *
-     * @param taskId 조회할 일정의 ID
-     * @return 일정 상세 정보를 포함한 API 응답
+     * @param taskId 조회할 일정 ID
+     * @return 일정 상세 응답 DTO
      */
     @GetMapping("/{taskId}")
     public ResponseEntity<ApiResponse<TaskDetailResponse>> getTaskById(@PathVariable Long taskId) {
@@ -83,12 +84,13 @@ public class TaskController {
     }
 
     /**
-     * 일정을 수정합니다. (제목, 설명, 마감일, 우선순위, 상태, 담당자 포함)
+     * 일정을 수정하는 API
+     * 제목, 설명, 마감일, 우선순위, 상태, 담당자 정보 수정 가능
      *
-     * @param taskId             수정 대상 일정 ID
-     * @param request            일정 수정 요청 DTO
-     * @param customUserDetails  인증된 사용자 정보
-     * @return 수정된 일정 상세 정보를 포함한 API 응답
+     * @param taskId            수정 대상 일정 ID
+     * @param request           일정 수정 요청 DTO
+     * @param customUserDetails 인증된 사용자 정보
+     * @return 수정된 일정 상세 응답 DTO
      */
     @LogActivity(value = ActivityType.TASK_UPDATED, target = "taskId")
     @PutMapping("/{taskId}")
@@ -105,13 +107,13 @@ public class TaskController {
     }
 
     /**
-     * 일정 상태만 별도로 변경합니다.
-     * 예: TODO → IN_PROGRESS → DONE 순으로만 가능
+     * 일정 상태만 변경하는 API
+     * 상태 전이 순서 (TODO → IN_PROGRESS → DONE) 검증 포함
      *
-     * @param taskId        대상 일정 ID
-     * @param request       상태 변경 요청 DTO
-     * @param userDetails   인증된 사용자 정보
-     * @return 상태가 변경된 일정 정보를 포함한 API 응답
+     * @param taskId      대상 일정 ID
+     * @param request     상태 변경 요청 DTO
+     * @param customUserDetails 인증된 사용자 정보
+     * @return 상태가 변경된 일정 상세 응답 DTO
      */
     @LogActivity(value = ActivityType.TASK_STATUS_CHANGED, target = "taskId")
     @PatchMapping("/{taskId}/status")
@@ -128,10 +130,10 @@ public class TaskController {
     }
 
     /**
-     * 일정을 삭제합니다. (soft delete 처리)
+     * 일정을 삭제하는 API (Soft Delete 방식)
      *
-     * @param taskId 삭제할 일정 ID
-     * @return 성공 메시지를 포함한 API 응답
+     * @param taskId 삭제 대상 일정 ID
+     * @return 삭제 성공 메시지를 포함한 응답
      */
     @LogActivity(value = ActivityType.TASK_DELETED, target = "taskId")
     @DeleteMapping("/{taskId}")

--- a/src/main/java/com/taskflow/domain/task/controller/TaskController.java
+++ b/src/main/java/com/taskflow/domain/task/controller/TaskController.java
@@ -15,7 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * 일정(Task) 관련 요청을 처리하는 컨트롤러입니다.
+ * TaskController는 일정(Task) 관련 HTTP 요청을 처리합니다.
  */
 @RestController
 @RequiredArgsConstructor
@@ -27,9 +27,9 @@ public class TaskController {
     /**
      * 새로운 일정을 생성합니다.
      *
-     * @param request       일정 생성 요청 DTO
-     * @param userDetails   로그인한 사용자 정보
-     * @return 생성된 일정 정보가 포함된 응답
+     * @param request      일정 생성 요청 DTO
+     * @param userDetails  인증된 사용자 정보
+     * @return 생성된 일정 정보와 함께 API 응답 반환
      */
     @LogActivity(ActivityType.TASK_CREATED)
     @PostMapping
@@ -45,14 +45,14 @@ public class TaskController {
     }
 
     /**
-     * 일정 목록을 조회합니다. (필터, 검색, 페이징 지원)
+     * 일정 목록을 필터, 검색, 페이징 기준으로 조회합니다.
      *
-     * @param status      일정 상태 (예: TODO, IN_PROGRESS)
+     * @param status      일정 상태 필터 (예: TODO, IN_PROGRESS)
      * @param page        페이지 번호
      * @param size        페이지 크기
-     * @param search      검색 키워드
-     * @param assigneeId  담당자 ID
-     * @return 일정 목록 및 페이징 정보
+     * @param search      제목 또는 설명 키워드
+     * @param assigneeId  담당자 ID로 필터링
+     * @return 조건에 맞는 일정 목록과 페이징 정보 포함 API 응답
      */
     @GetMapping
     public ResponseEntity<ApiResponse<TaskPageResponse>> getTasks(
@@ -69,10 +69,10 @@ public class TaskController {
     }
 
     /**
-     * 일정 단건을 조회합니다.
+     * 일정 ID를 기반으로 단건 일정을 조회합니다.
      *
      * @param taskId 조회할 일정의 ID
-     * @return 일정 상세 정보
+     * @return 일정 상세 정보를 포함한 API 응답
      */
     @GetMapping("/{taskId}")
     public ResponseEntity<ApiResponse<TaskDetailResponse>> getTaskById(@PathVariable Long taskId) {
@@ -83,12 +83,12 @@ public class TaskController {
     }
 
     /**
-     * 일정을 수정합니다.
+     * 일정을 수정합니다. (제목, 설명, 마감일, 우선순위, 상태, 담당자 포함)
      *
-     * @param taskId             수정할 일정의 ID
+     * @param taskId             수정 대상 일정 ID
      * @param request            일정 수정 요청 DTO
-     * @param customUserDetails  로그인한 사용자 정보
-     * @return 수정된 일정 정보 응답
+     * @param customUserDetails  인증된 사용자 정보
+     * @return 수정된 일정 상세 정보를 포함한 API 응답
      */
     @LogActivity(value = ActivityType.TASK_UPDATED, target = "taskId")
     @PutMapping("/{taskId}")
@@ -105,19 +105,22 @@ public class TaskController {
     }
 
     /**
-     * 일정 상태만 업데이트합니다.
+     * 일정 상태만 별도로 변경합니다.
+     * 예: TODO → IN_PROGRESS → DONE 순으로만 가능
      *
-     * @param taskId 일정 ID
-     * @param request 상태 변경 요청 DTO
-     * @return 상태가 변경된 일정 정보
+     * @param taskId        대상 일정 ID
+     * @param request       상태 변경 요청 DTO
+     * @param userDetails   인증된 사용자 정보
+     * @return 상태가 변경된 일정 정보를 포함한 API 응답
      */
     @LogActivity(value = ActivityType.TASK_STATUS_CHANGED, target = "taskId")
     @PatchMapping("/{taskId}/status")
     public ResponseEntity<ApiResponse<TaskDetailResponse>> updateTaskStatus(
             @PathVariable Long taskId,
-            @RequestBody @Valid TaskStatusUpdateRequest request) {
+            @RequestBody @Valid TaskStatusUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        TaskDetailResponse response = taskService.updateTaskStatus(taskId, request.getStatus());
+        TaskDetailResponse response = taskService.updateTaskStatus(taskId, request.getStatus(), customUserDetails.getId());
 
         return ResponseEntity
                 .status(TaskSuccess.TASK_STATUS_UPDATED_SUCCESS.getStatus())
@@ -125,10 +128,10 @@ public class TaskController {
     }
 
     /**
-     * 일정을 삭제합니다.
+     * 일정을 삭제합니다. (soft delete 처리)
      *
      * @param taskId 삭제할 일정 ID
-     * @return 성공 응답 메시지
+     * @return 성공 메시지를 포함한 API 응답
      */
     @LogActivity(value = ActivityType.TASK_DELETED, target = "taskId")
     @DeleteMapping("/{taskId}")

--- a/src/main/java/com/taskflow/domain/task/dto/TaskUpdateRequest.java
+++ b/src/main/java/com/taskflow/domain/task/dto/TaskUpdateRequest.java
@@ -42,7 +42,7 @@ public class TaskUpdateRequest {
     /**
      * 일정 상태
      */
-    @NotNull(message = "상태를 선택해주세요.")
+    //@NotNull(message = "상태를 선택해주세요.")
     private TaskStatus status;
 
     /**

--- a/src/main/java/com/taskflow/domain/task/service/TaskService.java
+++ b/src/main/java/com/taskflow/domain/task/service/TaskService.java
@@ -22,6 +22,10 @@ import java.util.stream.Collectors;
  * 일정(Task) 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
  * 일정 생성, 조회, 수정, 삭제, 상태 변경 기능을 제공합니다.
  */
+/**
+ * TaskService는 일정(Task) 도메인의 핵심 비즈니스 로직을 담당합니다.
+ * 일정 생성, 조회, 수정, 삭제, 상태 변경 기능을 제공합니다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -59,21 +63,21 @@ public class TaskService {
     }
 
     /**
-     * 일정 전체 조회
-     * 상태, 키워드, 담당자 ID 필터링 및 페이징 처리 포함
+     * 일정 목록을 조회합니다.
+     * 상태, 키워드, 담당자 ID 조건에 따라 필터링하며, 페이징 처리를 지원합니다.
      *
-     * @param status 필터링할 일정 상태
-     * @param page 페이지 번호
-     * @param size 페이지 크기
-     * @param search 제목 또는 설명 키워드
+     * @param status     필터링할 일정 상태
+     * @param page       페이지 번호
+     * @param size       페이지 크기
+     * @param search     제목 또는 설명 키워드
      * @param assigneeId 담당자 ID
-     * @return 페이징된 일정 리스트 응답
+     * @return 조건에 맞는 일정 목록과 페이징 정보 DTO
      */
     @Transactional(readOnly = true)
     public TaskPageResponse getTasks(TaskStatus status, Integer page, Integer size, String search, Long assigneeId) {
         List<Task> tasks = taskRepository.findAllByIsDeletedFalse();
 
-        // 필터링
+        // 조건별 필터링
         List<Task> filtered = tasks.stream()
                 .filter(task -> status == null || task.getStatus() == status)
                 .filter(task -> {
@@ -85,7 +89,7 @@ public class TaskService {
                 .filter(task -> assigneeId == null || Objects.equals(task.getAssignee().getId(), assigneeId))
                 .collect(Collectors.toList());
 
-        // 결과가 없을 경우 - 일부 조건만 예외 처리
+        // 결과 없음 처리
         if (filtered.isEmpty()) {
             if (search != null) {
                 throw new TaskNotFoundException(TaskError.TASK_NOT_FOUND_BY_SEARCH);
@@ -94,7 +98,7 @@ public class TaskService {
                 throw new TaskNotFoundException(TaskError.TASK_NOT_FOUND_BY_ASSIGNEE);
             }
 
-            // status만 조건이거나, 아예 조건 없을 경우엔 빈 결과 반환
+            // status만 있거나 조건이 아예 없을 경우 빈 응답
             return new TaskPageResponse(
                     Collections.emptyList(),
                     0,
@@ -104,7 +108,7 @@ public class TaskService {
             );
         }
 
-        // 페이징 계산
+        // 페이징 처리
         int start = (page != null && size != null) ? page * size : 0;
         int end = (size != null) ? Math.min(start + size, filtered.size()) : filtered.size();
         List<TaskResponse> paged = filtered.subList(start, end).stream()
@@ -120,12 +124,11 @@ public class TaskService {
         );
     }
 
-
     /**
-     * 일정 단건 조회
+     * 일정 단건을 조회합니다.
      *
      * @param taskId 조회할 일정 ID
-     * @return 일정 상세 정보
+     * @return 일정 상세 정보 DTO
      */
     public TaskDetailResponse getTaskById(Long taskId) {
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)
@@ -134,12 +137,13 @@ public class TaskService {
     }
 
     /**
-     * 일정을 수정합니다. 생성자 또는 담당자만 수정 권한이 있으며,
-     * 상태는 유효한 순서 (TODO → IN_PROGRESS → DONE)로만 변경 가능합니다.
+     * 일정을 수정합니다.
+     * 생성자 또는 담당자만 수정 가능하며,
+     * 상태 변경 시 순서(TODO → IN_PROGRESS → DONE) 유효성 검사를 수행합니다.
      *
      * @param taskId   수정할 일정 ID
-     * @param request  일정 수정 요청 DTO
-     * @param memberId 로그인한 사용자 ID
+     * @param request  수정 요청 DTO
+     * @param memberId 요청자 ID
      * @return 수정된 일정 상세 정보 DTO
      */
     public TaskDetailResponse updateTask(Long taskId, TaskUpdateRequest request, Long memberId) {
@@ -149,30 +153,29 @@ public class TaskService {
         Member assignee = memberRepository.findById(request.getAssigneeId())
                 .orElseThrow(AssigneeNotFoundException::new);
 
-        // 권한 확인: 요청자가 생성자 현재 할당된 담당자인지 확인
         if (!Objects.equals(task.getAssignee().getId(), memberId)
                 && !Objects.equals(task.getCreator().getId(), memberId)) {
             throw new UnauthorizedStatusChangeException();
         }
 
-
-
-        // 상태 순서 검증
         TaskStatus currentStatus = task.getStatus();
-        TaskStatus newStatus = request.getStatus();
+        TaskStatus newStatus = request.getStatus() != null ? request.getStatus() : currentStatus;
 
-        boolean validTransition =
-                (currentStatus == TaskStatus.TODO && newStatus == TaskStatus.IN_PROGRESS) ||
-                        (currentStatus == TaskStatus.IN_PROGRESS && newStatus == TaskStatus.DONE) ||
-                        (currentStatus == newStatus); // 같은 상태로는 허용
+        if (request.getStatus() != null) {
+            boolean validTransition =
+                    (currentStatus == TaskStatus.TODO && newStatus == TaskStatus.IN_PROGRESS) ||
+                            (currentStatus == TaskStatus.IN_PROGRESS && newStatus == TaskStatus.DONE) ||
+                            (currentStatus == newStatus);
 
-        if (!validTransition) {
-            throw new InvalidStatusTransitionException(); // 커스텀 예외
-        }
+            if (!validTransition) {
+                throw new InvalidStatusTransitionException();
+            }
 
-        // IN_PROGRESS 상태로 바뀔 때 시작일 기록
-        if (currentStatus != TaskStatus.IN_PROGRESS && newStatus == TaskStatus.IN_PROGRESS && task.getStartDate() == null) {
-            task.setStartDate(LocalDateTime.now());
+            if (currentStatus != TaskStatus.IN_PROGRESS
+                    && newStatus == TaskStatus.IN_PROGRESS
+                    && task.getStartDate() == null) {
+                task.setStartDate(LocalDateTime.now());
+            }
         }
 
         task.update(
@@ -188,7 +191,7 @@ public class TaskService {
     }
 
     /**
-     * 일정 삭제
+     * 일정을 삭제합니다. (소프트 삭제 처리)
      *
      * @param taskId 삭제할 일정 ID
      */
@@ -199,19 +202,42 @@ public class TaskService {
     }
 
     /**
-     * 일정 상태만 변경
+     * 일정 상태만 별도로 변경합니다.
+     * 생성자 또는 담당자만 상태 변경 가능하며,
+     * 상태 전이 규칙(TODO → IN_PROGRESS → DONE)을 검증합니다.
      *
-     * @param taskId 대상 일정 ID
-     * @param status 변경할 상태
-     * @return 상태가 변경된 일정 상세 정보
+     * @param taskId    일정 ID
+     * @param newStatus 요청된 상태
+     * @param memberId  요청자 ID
+     * @return 상태가 변경된 일정 상세 정보 DTO
      */
-    public TaskDetailResponse updateTaskStatus(Long taskId, TaskStatus status) {
+    public TaskDetailResponse updateTaskStatus(Long taskId, TaskStatus newStatus, Long memberId) {
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)
                 .orElseThrow(TaskNotFoundException::new);
-        if (status == null) {
-            throw new InvalidStatusException();
+
+        if (!Objects.equals(task.getAssignee().getId(), memberId)
+                && !Objects.equals(task.getCreator().getId(), memberId)) {
+            throw new UnauthorizedStatusChangeException();
         }
-        task.changeStatus(status);
+
+        TaskStatus currentStatus = task.getStatus();
+
+        boolean validTransition =
+                (currentStatus == TaskStatus.TODO && newStatus == TaskStatus.IN_PROGRESS) ||
+                        (currentStatus == TaskStatus.IN_PROGRESS && newStatus == TaskStatus.DONE) ||
+                        (currentStatus == newStatus);
+
+        if (!validTransition) {
+            throw new InvalidStatusTransitionException();
+        }
+
+        if (currentStatus != TaskStatus.IN_PROGRESS
+                && newStatus == TaskStatus.IN_PROGRESS
+                && task.getStartDate() == null) {
+            task.setStartDate(LocalDateTime.now());
+        }
+
+        task.changeStatus(newStatus);
         return new TaskDetailResponse(task);
     }
 }

--- a/src/main/java/com/taskflow/domain/task/service/TaskService.java
+++ b/src/main/java/com/taskflow/domain/task/service/TaskService.java
@@ -19,12 +19,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * 일정(Task) 도메인의 비즈니스 로직을 처리하는 서비스 클래스입니다.
- * 일정 생성, 조회, 수정, 삭제, 상태 변경 기능을 제공합니다.
- */
-/**
- * TaskService는 일정(Task) 도메인의 핵심 비즈니스 로직을 담당합니다.
- * 일정 생성, 조회, 수정, 삭제, 상태 변경 기능을 제공합니다.
+ * TaskService는 일정(Task) 도메인의 핵심 비즈니스 로직을 담당하는 서비스 클래스
+ * 일정 생성, 조회, 수정, 삭제, 상태 변경 기능 제공
  */
 @Service
 @RequiredArgsConstructor
@@ -35,11 +31,11 @@ public class TaskService {
     private final MemberRepository memberRepository;
 
     /**
-     * 일정을 생성합니다.
+     * 일정을 생성하는 서비스 로직
      *
-     * @param request   일정 생성 요청 DTO
-     * @param memberId  생성자 회원 ID
-     * @return 생성된 일정 상세 정보 DTO
+     * @param request  일정 생성 요청 DTO
+     * @param memberId 생성자 회원 ID
+     * @return 생성된 일정 상세 응답 DTO
      */
     public TaskDetailResponse createTask(TaskCreateRequest request, Long memberId) {
         Member creator = memberRepository.findById(memberId)
@@ -63,21 +59,20 @@ public class TaskService {
     }
 
     /**
-     * 일정 목록을 조회합니다.
-     * 상태, 키워드, 담당자 ID 조건에 따라 필터링하며, 페이징 처리를 지원합니다.
+     * 일정 목록을 조회하는 서비스 로직
+     * 상태, 키워드, 담당자 ID 필터링 및 페이징 처리 지원
      *
-     * @param status     필터링할 일정 상태
+     * @param status     일정 상태
      * @param page       페이지 번호
      * @param size       페이지 크기
-     * @param search     제목 또는 설명 키워드
+     * @param search     검색 키워드
      * @param assigneeId 담당자 ID
-     * @return 조건에 맞는 일정 목록과 페이징 정보 DTO
+     * @return 페이징 처리된 일정 목록 응답 DTO
      */
     @Transactional(readOnly = true)
     public TaskPageResponse getTasks(TaskStatus status, Integer page, Integer size, String search, Long assigneeId) {
         List<Task> tasks = taskRepository.findAllByIsDeletedFalse();
 
-        // 조건별 필터링
         List<Task> filtered = tasks.stream()
                 .filter(task -> status == null || task.getStatus() == status)
                 .filter(task -> {
@@ -89,7 +84,6 @@ public class TaskService {
                 .filter(task -> assigneeId == null || Objects.equals(task.getAssignee().getId(), assigneeId))
                 .collect(Collectors.toList());
 
-        // 결과 없음 처리
         if (filtered.isEmpty()) {
             if (search != null) {
                 throw new TaskNotFoundException(TaskError.TASK_NOT_FOUND_BY_SEARCH);
@@ -98,17 +92,14 @@ public class TaskService {
                 throw new TaskNotFoundException(TaskError.TASK_NOT_FOUND_BY_ASSIGNEE);
             }
 
-            // status만 있거나 조건이 아예 없을 경우 빈 응답
             return new TaskPageResponse(
                     Collections.emptyList(),
-                    0,
-                    0,
+                    0, 0,
                     size != null ? size : 0,
                     page != null ? page : 0
             );
         }
 
-        // 페이징 처리
         int start = (page != null && size != null) ? page * size : 0;
         int end = (size != null) ? Math.min(start + size, filtered.size()) : filtered.size();
         List<TaskResponse> paged = filtered.subList(start, end).stream()
@@ -125,10 +116,10 @@ public class TaskService {
     }
 
     /**
-     * 일정 단건을 조회합니다.
+     * 일정 단건을 조회하는 서비스 로직
      *
      * @param taskId 조회할 일정 ID
-     * @return 일정 상세 정보 DTO
+     * @return 일정 상세 응답 DTO
      */
     public TaskDetailResponse getTaskById(Long taskId) {
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)
@@ -137,14 +128,13 @@ public class TaskService {
     }
 
     /**
-     * 일정을 수정합니다.
-     * 생성자 또는 담당자만 수정 가능하며,
-     * 상태 변경 시 순서(TODO → IN_PROGRESS → DONE) 유효성 검사를 수행합니다.
+     * 일정을 수정하는 서비스 로직
+     * 생성자 또는 담당자만 수정 가능하며, 상태 순서 유효성 검증 포함
      *
      * @param taskId   수정할 일정 ID
      * @param request  수정 요청 DTO
-     * @param memberId 요청자 ID
-     * @return 수정된 일정 상세 정보 DTO
+     * @param memberId 요청자 회원 ID
+     * @return 수정된 일정 상세 응답 DTO
      */
     public TaskDetailResponse updateTask(Long taskId, TaskUpdateRequest request, Long memberId) {
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)
@@ -191,9 +181,9 @@ public class TaskService {
     }
 
     /**
-     * 일정을 삭제합니다. (소프트 삭제 처리)
+     * 일정을 삭제하는 서비스 로직 (Soft Delete 방식)
      *
-     * @param taskId 삭제할 일정 ID
+     * @param taskId 삭제 대상 일정 ID
      */
     public void deleteTask(Long taskId) {
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)
@@ -202,14 +192,13 @@ public class TaskService {
     }
 
     /**
-     * 일정 상태만 별도로 변경합니다.
-     * 생성자 또는 담당자만 상태 변경 가능하며,
-     * 상태 전이 규칙(TODO → IN_PROGRESS → DONE)을 검증합니다.
+     * 일정 상태만 별도로 변경하는 서비스 로직
+     * 생성자 또는 담당자만 변경 가능하며 상태 전이 순서 검증 포함
      *
      * @param taskId    일정 ID
-     * @param newStatus 요청된 상태
-     * @param memberId  요청자 ID
-     * @return 상태가 변경된 일정 상세 정보 DTO
+     * @param newStatus 변경할 상태
+     * @param memberId  요청자 회원 ID
+     * @return 상태가 변경된 일정 상세 응답 DTO
      */
     public TaskDetailResponse updateTaskStatus(Long taskId, TaskStatus newStatus, Long memberId) {
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)


### PR DESCRIPTION
주요 변경 사항
- 일정 상태(Status) 변경 시 순서 제한 로직 추가  
  - TODO → IN_PROGRESS → DONE 순서만 허용  
  - 동일 상태 유지도 허용, 역순 전이는 차단
- 일정 상태 변경 API(PATCH /{taskId}/status)에도 순서 검증 로직 반영
- 단건 일정 조회 후 수정 시 상태/담당자 변경이 안되던 문제 해결
  - `updateTask`, `updateTaskStatus` 메서드 내 권한 및 상태 조건 로직 수정
- 컨트롤러 및 서비스에 JavaDoc 주석 통일 적용

기타
- 프론트엔드 drag&drop 기반 상태 변경 대응